### PR TITLE
Line ending boundary and default encoding

### DIFF
--- a/NetFramework/HigLabo.Mime/Mime/Internal/MimeStreamBuffer.cs
+++ b/NetFramework/HigLabo.Mime/Mime/Internal/MimeStreamBuffer.cs
@@ -134,7 +134,12 @@ namespace HigLabo.Mime.Internal
                 //That avoid method call of CheckBoundary and improve performance.
                 if (*line_Start == 45 && boundaryLength > -1)
                 {
-                    var lastOfLine = this._Current - 2;
+                    //We found the end of the string by ASC 10 and assume that the end of the string is \r\n,
+                    var lastOfLine = this._Current - 1;
+                    //not in all cases :(
+                    if (*lastOfLine == 13)
+                        lastOfLine--;
+
                     var length = lastOfLine - line_Start + 1;
                     if (length == boundaryLength || length == boundaryLength + 2)
                     {

--- a/NetFramework/HigLabo.Mime/Mime/MimeParser.cs
+++ b/NetFramework/HigLabo.Mime/Mime/MimeParser.cs
@@ -731,7 +731,9 @@ namespace HigLabo.Mime
                 mc.BodyData = bodyBytes;
 
                 var charSet = mc.ContentType.CharsetEncoding;
-                if (charSet == null) { return; }
+                //if charset is ommit - use ASCII
+                if (charSet == null)
+                    charSet = Encoding.ASCII;
 
                 switch (mc.ContentTransferEncoding)
                 {


### PR DESCRIPTION
Hi!

I have a few fixes for your wonderful library!

In the attached file (some data is truncated), the encoding parameter is omitted in the message parts and \r in the last border marker.

Thunderbird read this letter perfectly.

[multipart_alternative_nocharset_trim.zip](https://github.com/higty/higlabo/files/6716417/multipart_alternative_nocharset_trim.zip)
