### PR TITLE
Auth Exception and Yandex settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
+*.bak
 
 # SQL Server files
 App_Data/*.mdf

--- a/Net5/HigLabo.Mail/Common/EmailServiceProvider.cs
+++ b/Net5/HigLabo.Mail/Common/EmailServiceProvider.cs
@@ -12,5 +12,6 @@ namespace HigLabo.Net.Mail
         YahooMail,
         AolMail,
         ZohoMail,
+        Yandex
     }
 }

--- a/Net5/HigLabo.Mail/Imap/ImapClient.cs
+++ b/Net5/HigLabo.Mail/Imap/ImapClient.cs
@@ -147,7 +147,7 @@ namespace HigLabo.Net.Imap
                 case EmailServiceProvider.YahooMail: serverName = "imap.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "imap.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "imap.zoho.com"; break;
-                case EmailServiceProvider.ZohoMail: serverName = "imap.yandex.ru"; break;
+                case EmailServiceProvider.Yandex: serverName = "imap.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;

--- a/Net5/HigLabo.Mail/Imap/ImapClient.cs
+++ b/Net5/HigLabo.Mail/Imap/ImapClient.cs
@@ -124,6 +124,7 @@ namespace HigLabo.Net.Imap
             if (userName.EndsWith("@yahoo.com")) { this.SetProperty(EmailServiceProvider.YahooMail); }
             if (userName.EndsWith("@aol.com")) { this.SetProperty(EmailServiceProvider.AolMail); }
             if (userName.EndsWith("@zoho.com")) { this.SetProperty(EmailServiceProvider.ZohoMail); }
+            if (userName.EndsWith("@yandex.ru")) { this.SetProperty(EmailServiceProvider.Yandex); }
         }
         public ImapClient(String serverName)
             : this(serverName, Default.Port, Default.UserName, Default.Password)
@@ -146,6 +147,7 @@ namespace HigLabo.Net.Imap
                 case EmailServiceProvider.YahooMail: serverName = "imap.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "imap.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "imap.zoho.com"; break;
+                case EmailServiceProvider.ZohoMail: serverName = "imap.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;

--- a/Net5/HigLabo.Mail/Pop3/Pop3Client.cs
+++ b/Net5/HigLabo.Mail/Pop3/Pop3Client.cs
@@ -76,6 +76,7 @@ namespace HigLabo.Net.Pop3
                 case EmailServiceProvider.YahooMail: serverName = "pop.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "pop.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "pop.zoho.com"; break;
+                case EmailServiceProvider.Yandex: serverName = "pop.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;

--- a/NetFramework/HigLabo.Mail/Common/EmailServiceProvider.cs
+++ b/NetFramework/HigLabo.Mail/Common/EmailServiceProvider.cs
@@ -12,5 +12,6 @@ namespace HigLabo.Net.Mail
         YahooMail,
         AolMail,
         ZohoMail,
+        Yandex
     }
 }

--- a/NetFramework/HigLabo.Mail/Imap/ImapClient.cs
+++ b/NetFramework/HigLabo.Mail/Imap/ImapClient.cs
@@ -154,7 +154,7 @@ namespace HigLabo.Net.Imap
                 case EmailServiceProvider.YahooMail: serverName = "imap.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "imap.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "imap.zoho.com"; break;
-                case EmailServiceProvider.ZohoMail: serverName = "imap.yandex.ru"; break;
+                case EmailServiceProvider.Yandex: serverName = "imap.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;

--- a/NetFramework/HigLabo.Mail/Imap/ImapClient.cs
+++ b/NetFramework/HigLabo.Mail/Imap/ImapClient.cs
@@ -154,6 +154,7 @@ namespace HigLabo.Net.Imap
                 case EmailServiceProvider.YahooMail: serverName = "imap.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "imap.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "imap.zoho.com"; break;
+                case EmailServiceProvider.ZohoMail: serverName = "imap.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;
@@ -1165,6 +1166,7 @@ namespace HigLabo.Net.Imap
                 commandText = String.Format(this.Tag + " FETCH {0} (BODY.PEEK[])", mailIndex);
             }
             var result = this.Execute(commandText);
+            if (result.Status == ImapCommandResultStatus.Bad) { throw new MailClientException(result.Text); }
             var text = this.GetMessageText(result.Text);
             this.MimeParser.Encoding = this.ResponseEncoding;
             return this.MimeParser.ToMailMessage(text);
@@ -1198,6 +1200,7 @@ namespace HigLabo.Net.Imap
             this.ValidateState(ImapConnectionState.Authenticated, true);
             String commandText = String.Format(this.Tag + " FETCH {0} (BODY.PEEK[])", this.CreateIndexList(mailIndexList));
             var result = this.Execute(commandText);
+            if (result.Status == ImapCommandResultStatus.Bad) { throw new MailClientException(result.Text); }
             var l = this.CreateMailMessages(result.Text);
             return l;
         }

--- a/NetFramework/HigLabo.Mail/Pop3/Pop3Client.cs
+++ b/NetFramework/HigLabo.Mail/Pop3/Pop3Client.cs
@@ -118,6 +118,7 @@ namespace HigLabo.Net.Pop3
                 case EmailServiceProvider.YahooMail: serverName = "pop.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "pop.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "pop.zoho.com"; break;
+                case EmailServiceProvider.Yandex: serverName = "pop.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;

--- a/NetStandard/HigLabo.Mail/Common/EmailServiceProvider.cs
+++ b/NetStandard/HigLabo.Mail/Common/EmailServiceProvider.cs
@@ -12,5 +12,6 @@ namespace HigLabo.Net.Mail
         YahooMail,
         AolMail,
         ZohoMail,
+        Yandex
     }
 }

--- a/NetStandard/HigLabo.Mail/Imap/ImapClient.cs
+++ b/NetStandard/HigLabo.Mail/Imap/ImapClient.cs
@@ -146,6 +146,7 @@ namespace HigLabo.Net.Imap
                 case EmailServiceProvider.YahooMail: serverName = "imap.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "imap.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "imap.zoho.com"; break;
+                case EmailServiceProvider.ZohoMail: serverName = "imap.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;

--- a/NetStandard/HigLabo.Mail/Imap/ImapClient.cs
+++ b/NetStandard/HigLabo.Mail/Imap/ImapClient.cs
@@ -146,7 +146,7 @@ namespace HigLabo.Net.Imap
                 case EmailServiceProvider.YahooMail: serverName = "imap.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "imap.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "imap.zoho.com"; break;
-                case EmailServiceProvider.ZohoMail: serverName = "imap.yandex.ru"; break;
+                case EmailServiceProvider.Yandex: serverName = "imap.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;

--- a/NetStandard/HigLabo.Mail/Pop3/Pop3Client.cs
+++ b/NetStandard/HigLabo.Mail/Pop3/Pop3Client.cs
@@ -76,6 +76,7 @@ namespace HigLabo.Net.Pop3
                 case EmailServiceProvider.YahooMail: serverName = "pop.mail.yahoo.com"; break;
                 case EmailServiceProvider.AolMail: serverName = "pop.aol.com"; break;
                 case EmailServiceProvider.ZohoMail: serverName = "pop.zoho.com"; break;
+                case EmailServiceProvider.Yandex: serverName = "pop.yandex.ru"; break;
                 default: throw new InvalidOperationException();
             }
             this.ServerName = serverName;


### PR DESCRIPTION
Hi, Higty!

I have a few additions for your wonderful library again!

-  When I tried authentication on some servers with the correct username and password, the attempts were unsuccessful.
It turned out that the response from the server contains a message like this "5.7.8 Error: authentication failed: Your message looks like spam. You need to use web for sending or prove you are not a robot using the following link http://ya.cc...."
I added an SmtpAuthenticate exception to inform the caller of this message.

- Added settings for Yandex (our local "Google")

- Changes have been made to the Net 5, Standard and Net Framework subfolders