### PR TITLE
Throw exception is authenticate fail

### DIFF
--- a/Net5/HigLabo.Mail/Smtp/SmtpClient.cs
+++ b/Net5/HigLabo.Mail/Smtp/SmtpClient.cs
@@ -417,6 +417,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -444,6 +448,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -467,6 +475,10 @@ namespace HigLabo.Net.Smtp
                 if (rs.StatusCode == SmtpCommandResultCode.AuthenticationSuccessful)
                 {
                     this._State = SmtpConnectionState.Authenticated;
+                }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
                 }
             }
             return this._State == SmtpConnectionState.Authenticated;

--- a/Net7/HigLabo.Mail/Smtp/SmtpClient.cs
+++ b/Net7/HigLabo.Mail/Smtp/SmtpClient.cs
@@ -292,6 +292,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -312,6 +316,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -328,6 +336,10 @@ namespace HigLabo.Net.Smtp
                 if (rs.StatusCode == SmtpCommandResultCode.AuthenticationSuccessful)
                 {
                     this._State = SmtpConnectionState.Authenticated;
+                }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
                 }
             }
             return this._State == SmtpConnectionState.Authenticated;

--- a/Net8/HigLabo.Mail/Smtp/SmtpClient.cs
+++ b/Net8/HigLabo.Mail/Smtp/SmtpClient.cs
@@ -292,6 +292,10 @@ public partial class SmtpClient : SocketClient, IDisposable
             {
                 this._State = SmtpConnectionState.Authenticated;
             }
+            else
+            {
+                throw new SmtpAuthenticateException(rs.Message);
+            }
         }
         return this._State == SmtpConnectionState.Authenticated;
     }
@@ -312,6 +316,10 @@ public partial class SmtpClient : SocketClient, IDisposable
             {
                 this._State = SmtpConnectionState.Authenticated;
             }
+            else
+            {
+                throw new SmtpAuthenticateException(rs.Message);
+            }
         }
         return this._State == SmtpConnectionState.Authenticated;
     }
@@ -328,6 +336,10 @@ public partial class SmtpClient : SocketClient, IDisposable
             if (rs.StatusCode == SmtpCommandResultCode.AuthenticationSuccessful)
             {
                 this._State = SmtpConnectionState.Authenticated;
+            }
+            else
+            {
+                throw new SmtpAuthenticateException(rs.Message);
             }
         }
         return this._State == SmtpConnectionState.Authenticated;

--- a/Net9/HigLabo.Mail/Smtp/SmtpClient.cs
+++ b/Net9/HigLabo.Mail/Smtp/SmtpClient.cs
@@ -292,6 +292,10 @@ public partial class SmtpClient : SocketClient, IDisposable
             {
                 this._State = SmtpConnectionState.Authenticated;
             }
+            else
+            {
+                throw new SmtpAuthenticateException(rs.Message);
+            }
         }
         return this._State == SmtpConnectionState.Authenticated;
     }
@@ -312,6 +316,10 @@ public partial class SmtpClient : SocketClient, IDisposable
             {
                 this._State = SmtpConnectionState.Authenticated;
             }
+            else
+            {
+                throw new SmtpAuthenticateException(rs.Message);
+            }
         }
         return this._State == SmtpConnectionState.Authenticated;
     }
@@ -328,6 +336,10 @@ public partial class SmtpClient : SocketClient, IDisposable
             if (rs.StatusCode == SmtpCommandResultCode.AuthenticationSuccessful)
             {
                 this._State = SmtpConnectionState.Authenticated;
+            }
+            else
+            {
+                throw new SmtpAuthenticateException(rs.Message);
             }
         }
         return this._State == SmtpConnectionState.Authenticated;

--- a/NetFramework/HigLabo.Mail/Smtp/SmtpClient.cs
+++ b/NetFramework/HigLabo.Mail/Smtp/SmtpClient.cs
@@ -417,6 +417,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -444,6 +448,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -467,6 +475,10 @@ namespace HigLabo.Net.Smtp
                 if (rs.StatusCode == SmtpCommandResultCode.AuthenticationSuccessful)
                 {
                     this._State = SmtpConnectionState.Authenticated;
+                }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
                 }
             }
             return this._State == SmtpConnectionState.Authenticated;

--- a/NetStandard/HigLabo.Mail/Smtp/SmtpClient.cs
+++ b/NetStandard/HigLabo.Mail/Smtp/SmtpClient.cs
@@ -417,6 +417,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -444,6 +448,10 @@ namespace HigLabo.Net.Smtp
                 {
                     this._State = SmtpConnectionState.Authenticated;
                 }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
+                }
             }
             return this._State == SmtpConnectionState.Authenticated;
         }
@@ -467,6 +475,10 @@ namespace HigLabo.Net.Smtp
                 if (rs.StatusCode == SmtpCommandResultCode.AuthenticationSuccessful)
                 {
                     this._State = SmtpConnectionState.Authenticated;
+                }
+                else
+                {
+                    throw new SmtpAuthenticateException(rs.Message);
                 }
             }
             return this._State == SmtpConnectionState.Authenticated;


### PR DESCRIPTION
Hi!

I have again a few improvements for your wonderful library!

If login attempt failed we don't know the reason.

It may be wrong password, like this:

535 5.7.8 Error: authentication failed: Invalid user or password! 1774455537-vIXT90VGqGk0

or something else:

5.7.8 Error: authentication failed: Your message looks like spam. You need to use web for sending or prove you are not a robot using the following link http://ya.cc...

and we won't understand what's going on.

When an exception occurs, we'll see the reason in the message member.

Perhaps this behavior should be added to other protocols (IMAP, POP3), but so far it has only been useful to me in SMTP.